### PR TITLE
Allow cross origin requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,11 @@
 			<artifactId>quartz</artifactId>
 			<version>2.2.2</version>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlets</artifactId>
+			<version>9.3.5.v20151012</version>
+		</dependency>		
 	</dependencies>
 	<properties>
 		<jersey.version>2.22</jersey.version>

--- a/src/main/java/com/newput/rest/resource/EmpController.java
+++ b/src/main/java/com/newput/rest/resource/EmpController.java
@@ -187,6 +187,7 @@ public class EmpController {
 	 *         it get failed when either user is not registered or either email
 	 *         id or password is wrong.
 	 */
+
 	@Path("/login")
 	@POST
 	@Produces(MediaType.APPLICATION_JSON)

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -43,4 +43,25 @@
 		<filter-name>SessionFilter</filter-name>
 		<url-pattern>/rest/employee/*</url-pattern>
 	</filter-mapping>
+	<!-- allow cross origin requests -->
+	<filter>
+		<filter-name>cross-origin</filter-name>
+		<filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
+		<init-param>
+			<param-name>allowedOrigins</param-name>
+			<param-value>*</param-value>
+		</init-param>
+		<init-param>
+			<param-name>allowedMethods</param-name>
+			<param-value>*</param-value>
+		</init-param>
+		<init-param>
+			<param-name>allowedHeaders</param-name>
+			<param-value>*</param-value>
+		</init-param>
+	</filter>
+	<filter-mapping>
+		<filter-name>cross-origin</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
 </web-app>


### PR DESCRIPTION
@DeeptiNewput @rahulkulmi 

I have updated web.xml to allow cross origin requests from UI as explained on this link:
http://stackoverflow.com/questions/8303162/jetty-cross-origin-filter

But some it shows me an error wtih these logs. So, please look into it ad make a provision to allow cross origin requests.

`
java.lang.ClassNotFoundException: org.eclipse.jetty.servlets.CrossOriginFilter
	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1333)
	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1167)
	at org.apache.catalina.core.DefaultInstanceManager.loadClass(DefaultInstanceManager.java:520)
	at org.apache.catalina.core.DefaultInstanceManager.loadClassMaybePrivileged(DefaultInstanceManager.java:501)
	at org.apache.catalina.core.DefaultInstanceManager.newInstance(DefaultInstanceManager.java:120)
	at org.apache.catalina.core.ApplicationFilterConfig.getFilter(ApplicationFilterConfig.java:258)
	at org.apache.catalina.core.ApplicationFilterConfig.<init>(ApplicationFilterConfig.java:105)
	at org.apache.catalina.core.StandardContext.filterStart(StandardContext.java:4583)
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5207)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1408)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1398)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
`